### PR TITLE
Fix display of the errors when trying to add a blacklist

### DIFF
--- a/BanHammer/blacklist/templates/blacklist/post.html
+++ b/BanHammer/blacklist/templates/blacklist/post.html
@@ -18,7 +18,7 @@
 
 <div class="banner">Apply a new network-wide blacklist</div>
 {% if form.errors %}
-{{ form.non_field_errors }}
+{{ form.non_field_errors() }}
 <!--
 {% for field in form %}
 {{ field.errors }}


### PR DESCRIPTION
form.non_field_errors is a method:  <bound method ComplaintForm.non_field_errors of <BanHammer.blacklist.models.ComplaintForm object at 0x1078df850>> 
